### PR TITLE
Use vpc cidr for efs sg unless overridden

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,7 @@
 locals {
   # VPC - existing or new?
   vpc_id             = var.vpc_id == "" ? module.vpc.vpc_id : var.vpc_id
+  cidr               = var.cidr == "" ? data.aws_vpc.this.cidr : var.cidr
   private_subnet_ids = coalescelist(module.vpc.private_subnets, var.private_subnet_ids, [""])
   public_subnet_ids  = coalescelist(module.vpc.public_subnets, var.public_subnet_ids, [""])
 
@@ -135,6 +136,10 @@ data "aws_route53_zone" "this" {
 
   name         = var.route53_zone_name
   private_zone = var.route53_private_zone
+}
+
+data "aws_vpc" "this" {
+  id = local.vpc_id
 }
 
 ################################################################################
@@ -383,7 +388,8 @@ module "efs_sg" {
   vpc_id      = local.vpc_id
   description = "Security group allowing access to the EFS storage"
 
-  ingress_cidr_blocks = [var.cidr]
+  ingress_cidr_blocks = [local.cidr]
+
   ingress_with_source_security_group_id = [{
     rule                     = "nfs-tcp",
     source_security_group_id = module.atlantis_sg.security_group_id

--- a/main.tf
+++ b/main.tf
@@ -1,9 +1,9 @@
 locals {
   # VPC - existing or new?
-  vpc_id             = var.vpc_id == "" ? module.vpc.vpc_id : var.vpc_id
-  cidr               = var.cidr == "" ? data.aws_vpc.this.cidr : var.cidr
-  private_subnet_ids = coalescelist(module.vpc.private_subnets, var.private_subnet_ids, [""])
-  public_subnet_ids  = coalescelist(module.vpc.public_subnets, var.public_subnet_ids, [""])
+  vpc_id              = var.vpc_id == "" ? module.vpc.vpc_id : var.vpc_id
+  efs_sg_ingress_cidr = [ var.cidr == "" ? data.aws_vpc.this.cidr : var.cidr ]
+  private_subnet_ids  = coalescelist(module.vpc.private_subnets, var.private_subnet_ids, [""])
+  public_subnet_ids   = coalescelist(module.vpc.public_subnets, var.public_subnet_ids, [""])
 
   # Atlantis
   atlantis_image = var.atlantis_image == "" ? "ghcr.io/runatlantis/atlantis:${var.atlantis_version}" : var.atlantis_image
@@ -388,7 +388,7 @@ module "efs_sg" {
   vpc_id      = local.vpc_id
   description = "Security group allowing access to the EFS storage"
 
-  ingress_cidr_blocks = [local.cidr]
+  ingress_cidr_blocks = local.efs_sg_ingress_cidr
 
   ingress_with_source_security_group_id = [{
     rule                     = "nfs-tcp",


### PR DESCRIPTION
## what
- Use vpc cidr for efs sg unless overridden

## why
- The module allows passing in a `cidr` to create a vpc and use that same `cidr` as `ingress_cidr_blocks` to the efs sg.
- If a `vpc_id` is passed in, the hcl will still use the `cidr` input to set the efs sg
- This change will continue to let `cidr` input as the efs sg ingress cidr blocks but if it is left empty (default), the efs sg ingress cidr blocks will default to the vpcs cidr, either the vpc passed in or the vpc created.

## references
- Thanks to @bodgit for the original fix in https://github.com/bodgit/terraform-aws-atlantis/commit/54bd2d9a043e0e82937aa1ba724e8a08677d3acf
- Closes https://github.com/terraform-aws-modules/terraform-aws-atlantis/issues/252
